### PR TITLE
use attribute instead global in GAN example

### DIFF
--- a/vignettes/examples/eager_dcgan.R
+++ b/vignettes/examples/eager_dcgan.R
@@ -175,8 +175,8 @@ generate_and_save_images <- function(model, epoch, test_input) {
   dev.off()
 }
 
-train <- function(dataset, epochs, noise_dim) {
-  for (epoch in seq_len(num_epochs)) {
+train <- function(dataset,epochs, noise_dim) {
+  for (epoch in seq_len(epochs)) {
     start <- Sys.time()
     total_loss_gen <- 0
     total_loss_disc <- 0


### PR DESCRIPTION
* change in train function in eager gan example is using global variable `num_epochs`, instead one passed as an attribute